### PR TITLE
fix pr base branch

### DIFF
--- a/.github/workflows/generate-regressions.yml
+++ b/.github/workflows/generate-regressions.yml
@@ -102,7 +102,7 @@ jobs:
             exit
           create-pr: true
           branch: ${{ inputs.base-branch }}
-          pr-base: ${{ inputs.base-branch }}
+          pr-base: main
           pr-title: "TestDriver.ai / Run Regression / ${{ matrix.markdown }}"
           pr-branch: ${{ steps.generate-pr-branch.outputs.pr-branch }}
           pr-test-filename: ${{steps.generate-filename.outputs.filename}}


### PR DESCRIPTION
There's a bug where all the PRs have base branch as the exploratory branch expect for the main "Test Plan" PR.

![image](https://github.com/user-attachments/assets/847ec3ef-be2f-4747-9e3b-eda333d3fdb8)

Example PR - https://github.com/testdriverbot/betaworkscom-1742397898080/pull/3